### PR TITLE
Add cperl-mode faces

### DIFF
--- a/flucui-dark-theme.el
+++ b/flucui-dark-theme.el
@@ -175,6 +175,11 @@
    `(company-scrollbar-bg ((t (:background ,fui-bg))))
    `(company-scrollbar-fg ((t (:background ,fui-asphalt))))
 
+   ;; Cperl
+   `(cperl-array-face ((t (:weight bold :inherit font-lock-variable-name-face))))
+   `(cperl-hash-face ((t (:weight bold :slant italic :inherit font-lock-variable-name-face))))
+   `(cperl-nonoverridable-face ((t (:inherit font-lock-builtin-face))))
+
    ;; Powerline
    `(mode-line ((t (:box nil))))
    `(powerline-active2 ((t (:foreground ,fui-fg :background ,fui-dark-clouds))))

--- a/flucui-light-theme.el
+++ b/flucui-light-theme.el
@@ -175,6 +175,11 @@
    `(company-scrollbar-bg ((t (:background ,fui-bg))))
    `(company-scrollbar-fg ((t (:background ,fui-dark-clouds))))
 
+   ;; Cperl
+   `(cperl-array-face ((t (:weight bold :inherit font-lock-variable-name-face))))
+   `(cperl-hash-face ((t (:weight bold :slant italic :inherit font-lock-variable-name-face))))
+   `(cperl-nonoverridable-face ((t (:inherit font-lock-builtin-face))))
+
    ;; Powerline
    `(mode-line ((t (:box nil))))
    `(powerline-active2 ((t (:foreground ,fui-fg :background ,fui-dark-clouds))))


### PR DESCRIPTION
I kept the same style regarding bold and italic for the hash and array variables, but inherited from the variable face for consistency.
For the nonoverridable face, I just inherited from the builtin face.

![flucui](https://user-images.githubusercontent.com/1592315/48922077-6e74dd80-eea4-11e8-8e3c-c28d45b12cc3.png)
